### PR TITLE
Adding missing logic to enable TCP TLS server

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -74,6 +74,10 @@ func New(options *Options) (*Runner, error) {
 // Run logic
 func (r *Runner) Run() error {
 	if r.options.EnableTCP {
+		if r.options.TCPWithTLS {
+			gologger.Print().Msgf("Serving TCP rule based tls server on tcp://%s", r.options.ListenAddress)
+			return r.serverTCP.ListenAndServeTLS()
+		}
 		gologger.Print().Msgf("Serving TCP rule based server on tcp://%s", r.options.ListenAddress)
 		return r.serverTCP.ListenAndServe()
 	}


### PR DESCRIPTION
This PR adds missing logic to enable tcp tls server with custom responses:

**rules.yaml**
```yaml
rules:
  - match: hey 
    response: |
              HTTP/1.0 200 OK
              Server: httpd/2.0
              x-frame-options: SAMEORIGIN
              x-xss-protection: 1; mode=block
              Date: Fri, 16 Apr 2021 14:30:32 GMT
              Content-Type: text/html
              Connection: close

              hello
```

**server**
```console
$ sudo go run . -tcp -rules rules.yaml -listen 127.0.0.1:443 -tls

   _____ _                 __     __  __________________                                
  / ___/(_)___ ___  ____  / /__  / / / /_  __/_  __/ __ \________  ______   _____  _____
  \__ \/ / __ -__ \/ __ \/ / _ \/ /_/ / / /   / / / /_/ / ___/ _ \/ ___/ | / / _ \/ ___/
 ___/ / / / / / / / /_/ / /  __/ __  / / /   / / / ____(__  )  __/ /   | |/ /  __/ /    
/____/_/_/ /_/ /_/ .___/_/\___/_/ /_/ /_/   /_/ /_/   /____/\___/_/    |___/\___/_/     
                /_/                                                       - v0.0.4

                projectdiscovery.io

Use with caution. You are responsible for your actions
Developers assume no liability and are not responsible for any misuse or damage.
Serving TCP rule based tls server on tcp://127.0.0.1:443
hey / HTTP/1.1
Host: localhost
User-Agent: curl/7.77.0
Accept: */*


HTTP/1.0 200 OK
Server: httpd/2.0
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block
Date: Fri, 16 Apr 2021 14:30:32 GMT
Content-Type: text/html
Connection: close

hello 
```

**client**
```console
$ curl -X hey https://localhost/ -k -v
*   Trying ::1:443...
* connect to ::1 port 443 failed: Connection refused
*   Trying 127.0.0.1:443...
* Connected to localhost (127.0.0.1) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: O=Acme Co
*  start date: Dec 21 15:45:45 2021 GMT
*  expire date: Dec 21 15:45:45 2022 GMT
*  issuer: O=Acme Co
*  SSL certificate verify result: unable to get local issuer certificate (20), continuing anyway.
> hey / HTTP/1.1
> Host: localhost
> User-Agent: curl/7.77.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
* HTTP 1.0, assume close after body
< HTTP/1.0 200 OK
< Server: httpd/2.0
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< Date: Fri, 16 Apr 2021 14:30:32 GMT
< Content-Type: text/html
< Connection: close
< 
* TLSv1.2 (IN), TLS alert, close notify (256):
* Closing connection 0
* TLSv1.2 (OUT), TLS alert, close notify (256):
```
