### PR TITLE
Add support for custom HTTP response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This will display help for the tool. Here are all the switches it supports.
 | `-realm`         | Basic auth message                                      | `simplehttpserver -realm "insert the credentials"` |
 | `-version`       | Show version                                            | `simplehttpserver -version`                        |
 | `-silent`        | Show only results                                       | `simplehttpserver -silent`                         |
-| `-header`        | dd HTTP Response Header (can be used multiple times)    | `simplehttpserver -header 'X-Powered-By: Go'`      |
+| `-header`        | HTTP response header (can be used multiple times)       | `simplehttpserver -header 'X-Powered-By: Go'`      |
 
 ### Running simplehttpserver in the current folder  
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This will display help for the tool. Here are all the switches it supports.
 | `-realm`         | Basic auth message                                      | `simplehttpserver -realm "insert the credentials"` |
 | `-version`       | Show version                                            | `simplehttpserver -version`                        |
 | `-silent`        | Show only results                                       | `simplehttpserver -silent`                         |
+| `-header`        | dd HTTP Response Header (can be used multiple times)    | `simplehttpserver -header 'X-Powered-By: Go'`      |
 
 ### Running simplehttpserver in the current folder  
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -68,6 +68,7 @@ func New(options *Options) (*Runner, error) {
 		MaxFileSize:       r.options.MaxFileSize,
 		HTTP1Only:         r.options.HTTP1Only,
 		MaxDumpBodySize:   unit.ToMb(r.options.MaxDumpBodySize),
+		HTTPHeaders:       r.options.HTTPHeaders,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/httpserver/headerlayer.go
+++ b/pkg/httpserver/headerlayer.go
@@ -1,0 +1,20 @@
+package httpserver
+
+import (
+	"net/http"
+)
+
+// HTTPHeader represents an HTTP header
+type HTTPHeader struct {
+	Name  string
+	Value string
+}
+
+func (t *HTTPServer) headerlayer(handler http.Handler, headers []HTTPHeader) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, header := range headers {
+			w.Header().Set(header.Name, header.Value)
+		}
+		handler.ServeHTTP(w, r)
+	})
+}

--- a/pkg/httpserver/httpserver.go
+++ b/pkg/httpserver/httpserver.go
@@ -27,6 +27,7 @@ type Options struct {
 	HTTP1Only         bool
 	MaxFileSize       int // 50Mb
 	MaxDumpBodySize   int64
+	HTTPHeaders       []HTTPHeader
 }
 
 // HTTPServer instance
@@ -72,6 +73,7 @@ func New(options *Options) (*HTTPServer, error) {
 	}
 
 	httpHandler = h.loglayer(httpHandler)
+	httpHandler = h.headerlayer(httpHandler, options.HTTPHeaders)
 
 	// add handler
 	h.layers = httpHandler


### PR DESCRIPTION
This adds a new command line option `-header` to allow setting custom response headers. Can be used multiple times to set many of them. Addresses parts of #41  as well as #40 . My primary use case is CORS support.

For example, you can do: `simplehttpserver -header 'Access-Control-Allow-Origin: *' -header 'X-Powered-By: simplehttpserver' -path /tmp/www/'` to set two custom headers. 