### PR TITLE
[proposal] pythonliststyle: Add viewport meta tag

### DIFF
--- a/pkg/httpserver/pythonliststyle.go
+++ b/pkg/httpserver/pythonliststyle.go
@@ -17,6 +17,7 @@ const (
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Directory listing for %s</title>
 </head>
 <body>

--- a/test/pythonliststyle_test.go
+++ b/test/pythonliststyle_test.go
@@ -15,6 +15,7 @@ func TestServePythonStyleHtmlPageForDirectories(t *testing.T) {
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Directory listing for /</title>
 </head>
 <body>


### PR DESCRIPTION
This makes the rendered HTML appear equally-sized on both mobile and desktop displays.
| Before | After |
| -- | -- |
| ![photo_2023-06-09_23-03-26 (2)](https://github.com/projectdiscovery/simplehttpserver/assets/3787795/8606e530-e777-4b50-bc08-7cc44268462f) | ![photo_2023-06-09_23-03-26](https://github.com/projectdiscovery/simplehttpserver/assets/3787795/bd1768aa-0e8c-4d6a-aadb-04b908acbd74) |

#### Notes
1. Although this is not present in the original `$ python -m http.server` command I found that there is a subtle difference between the `simplehttpserver` and python commands (on Windows at least) with regards to sorting of the listed files & directories, so I decided that it is acceptable for this difference as well.
2. I saw that the [pythonliststyle_test.go](https://github.com/xswordsx/simplehttpserver/blob/13a930f33088cd748772714f804a9a6b21bd95cf/test/pythonliststyle_test.go#L5) imports are not formatted with `goimports` but I didn't want to clutter the PR.
3. I was tempted to do the same for the default server, but I saw the the Go FileServer doesn't return full HTML but rather just a `<pre>` tag. Adding a new handler just for that seemed like it would make the code harder to read for a diminishing gain (not to mention the possible slow-down).

